### PR TITLE
Two new options added

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Usage: ./simplylock [-slkhv] [-u users] [-m message]
 -s           Keep sysrequests enabled.
 -l           Do not lock terminal switching.
 -k           Do not mute kernel messages while the console is locked.
+-q           Quick unlock mode.
+-d           Turn off the backlight of the screen.
 -u user      Comma separated list of users allowed to unlock.
              Note that the root user will always be able to unlock.
 -m message   Display the given message instead of the default one.

--- a/main.c
+++ b/main.c
@@ -196,10 +196,16 @@ int main(int argc, char** argv) {
         fprintf(stdout, "\nPress enter to unlock as " HIGHLIGHT "%s" RESET ". [Press Ctrl+C to change user] ", user);
 
         user_selection_enabled = 1;
-        c = fgetc(stdin);
-        while (c != EOF && c != '\n') {
+
+        if (options->quick_unlock != 0) {
+            options->quick_unlock = 0;
+        } else {
             c = fgetc(stdin);
+            while (c != EOF && c != '\n') {
+                c = fgetc(stdin);
+            }
         }
+
         if (c == EOF) {
             perror("getchar");
             goto error;

--- a/options.c
+++ b/options.c
@@ -14,11 +14,12 @@ static char* root_username = "root";
 static void print_usage(int argc, char** argv) {
     fprintf(
         stderr,
-        "Usage: %s [-slkhv] [-u users] [-m message]\n"
+        "Usage: %s [-slkqhv] [-u users] [-m message]\n"
         "\n"
         "-s           Keep sysrequests enabled.\n"
         "-l           Do not lock terminal switching.\n"
         "-k           Do not mute kernel messages while the console is locked.\n"
+        "-q           Quick unlock mode.\n"
         "-u user      Comma separated list of users allowed to unlock.\n"
         "             Note that the root user will always be able to unlock.\n"
         "-m message   Display the given message instead of the default one.\n"
@@ -110,6 +111,7 @@ struct options* options_parse(int argc, char** argv) {
     options->block_sysrequests = 1;
     options->block_vt_switch = 1;
     options->block_kernel_messages = 1;
+    options->quick_unlock = 0;
     options->users = NULL;
     options->message = NULL;
     options->show_help = 0;
@@ -117,7 +119,7 @@ struct options* options_parse(int argc, char** argv) {
 
     // Args parsing
     int opt;
-    while ((opt = getopt(argc, argv, "slku:m:hv")) != -1) {
+    while ((opt = getopt(argc, argv, "slkqu:m:hv")) != -1) {
         switch (opt) {
             case 's':
                 options->block_sysrequests = 0;
@@ -127,6 +129,9 @@ struct options* options_parse(int argc, char** argv) {
                 break;
             case 'k':
                 options->block_kernel_messages = 0;
+                break;
+            case 'q':
+                options->quick_unlock = 1;
                 break;
             case 'u':
                 if (split_users(options, optarg) < 0) {

--- a/options.h
+++ b/options.h
@@ -9,6 +9,7 @@ struct options {
     unsigned int block_vt_switch;
     unsigned int block_kernel_messages;
     unsigned int quick_unlock;
+    unsigned int backlight_off;
     char** users;
     unsigned int users_size;
     char* message;
@@ -24,7 +25,7 @@ struct options {
  *    @return      `struct options` containing the parsed options,
  *                 or `NULL` in case of an error, and sets `errno`.
  */
-struct options* options_parse(int argc, char** argv);
+struct options* options_parse(int argc, char** argv, uid_t uid);
 
 /**
  *    Releases all the resources allocated for a `struct options`.

--- a/options.h
+++ b/options.h
@@ -8,6 +8,7 @@ struct options {
     unsigned int block_sysrequests;
     unsigned int block_vt_switch;
     unsigned int block_kernel_messages;
+    unsigned int quick_unlock;
     char** users;
     unsigned int users_size;
     char* message;


### PR DESCRIPTION
1. Quick unlock mode (-q)
    Normally you should press the Enter key to authenticate, with this option it is not necessary.

2. Dark mode (-d)
    Turns off the backlight of the screen until the Enter button is pressed.
    In Quick unlock mode, the backlight is turned on after the first attempt to authenticate.